### PR TITLE
Prevent webhook server shutdown crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ A Telegram bot that receives messages and responds using Grok agent via LangChai
    # Edit .env with your TELEGRAM_BOT_TOKEN and XAI_API_KEY
    ```
 
-3. Run the bot:
+3. (Optional) Configure GitHub Pull Request notifications:
+
+   - Add `GITHUB_PR_CHAT_ID` to `.env` with the Telegram chat ID that should receive
+     alerts when a pull request is opened.
+   - Optionally set `GITHUB_WEBHOOK_HOST` and `GITHUB_WEBHOOK_PORT` to control where
+     the webhook server listens. The default is `0.0.0.0:8000`.
+
+4. Run the bot:
    ```
    python main.py
    ```
+
+   The GitHub webhook endpoint will be available at
+   `http://<host>:<port>/github/webhook`.
 
 ## Obtaining API Keys
 

--- a/main.py
+++ b/main.py
@@ -1,11 +1,17 @@
-import os
+import asyncio
+import json
 import logging
+import os
+from typing import Optional
+
+from aiohttp import ContentTypeError, web
 from dotenv import load_dotenv
-from telegram import Update
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
-from langchain_xai import ChatXAI
-from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
 from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_xai import ChatXAI
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
+
 from system_prompt import create_system_prompt
 
 class SimpleChatMessageHistory(BaseChatMessageHistory):
@@ -67,12 +73,87 @@ load_dotenv()
 
 BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 XAI_API_KEY = os.getenv('XAI_API_KEY')
+GITHUB_CHAT_ID_ENV = os.getenv('GITHUB_PR_CHAT_ID')
+WEBHOOK_HOST = os.getenv('GITHUB_WEBHOOK_HOST', '0.0.0.0')
+WEBHOOK_PORT = int(os.getenv('GITHUB_WEBHOOK_PORT', '8000'))
+
+telegram_application: Optional[Application] = None
+webhook_runner: Optional[web.AppRunner] = None
+
+def _parse_chat_id(chat_id_env: Optional[str]) -> Optional[int]:
+    """환경 변수에서 읽은 채팅 ID를 정수로 변환합니다."""
+
+    if not chat_id_env:
+        return None
+
+    try:
+        return int(chat_id_env)
+    except ValueError:
+        logging.error("잘못된 GITHUB_PR_CHAT_ID 값입니다: %s", chat_id_env)
+        return None
+
+
+GITHUB_CHAT_ID = _parse_chat_id(GITHUB_CHAT_ID_ENV)
 
 llm = ChatXAI(
     model_name="grok-4-fast-non-reasoning",
     xai_api_key=XAI_API_KEY,
     xai_api_base="https://api.x.ai/v1",
 )
+
+
+async def handle_github_webhook(request: web.Request) -> web.StreamResponse:
+    """GitHub Pull Request 웹훅을 처리합니다."""
+
+    if GITHUB_CHAT_ID is None:
+        logging.warning("GITHUB_PR_CHAT_ID가 설정되지 않아 웹훅 알림을 보낼 수 없습니다.")
+        return web.Response(status=503, text='Chat ID not configured')
+
+    if telegram_application is None:
+        logging.warning("텔레그램 애플리케이션이 아직 초기화되지 않았습니다.")
+        return web.Response(status=503, text='Bot not ready')
+
+    try:
+        payload = await request.json()
+    except (json.JSONDecodeError, ContentTypeError):
+        logging.exception("잘못된 JSON 페이로드입니다.")
+        return web.Response(status=400, text='Invalid JSON payload')
+
+    action = payload.get('action')
+    pull_request = payload.get('pull_request')
+
+    # pull_request 필드가 없는 이벤트는 무시합니다.
+    if not pull_request:
+        return web.Response(status=200, text='Event ignored')
+
+    if action not in {'opened', 'reopened'}:
+        logging.info("지원하지 않는 PR 액션입니다: %s", action)
+        return web.Response(status=200, text='Action ignored')
+
+    repo_info = payload.get('repository', {})
+    sender_info = payload.get('sender', {})
+
+    repo_name = repo_info.get('full_name', '알 수 없는 저장소')
+    pr_title = pull_request.get('title', '제목 없음')
+    pr_url = pull_request.get('html_url', '')
+    sender_login = sender_info.get('login')
+
+    message_lines = [f"📣 {repo_name} 저장소에 새로운 Pull Request가 생성되었습니다."]
+    message_lines.append(f"제목: {pr_title}")
+    if sender_login:
+        message_lines.append(f"작성자: {sender_login}")
+    if pr_url:
+        message_lines.append(pr_url)
+
+    message = '\n'.join(message_lines)
+
+    try:
+        await telegram_application.bot.send_message(chat_id=GITHUB_CHAT_ID, text=message)
+    except Exception:
+        logging.exception("GitHub PR 알림 전송 중 오류가 발생했습니다.")
+        return web.Response(status=500, text='Failed to send message')
+
+    return web.Response(status=200, text='Notification sent')
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # 메시지가 없는 업데이트는 무시
@@ -137,15 +218,66 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     except Exception as e:
         await update.message.reply_text(f'Sorry, something went wrong: {str(e)}')
 
-def main() -> None:
+async def start_webhook_server() -> None:
+    """GitHub 웹훅 서버를 시작합니다."""
+
+    global webhook_runner
+
+    if webhook_runner is not None:
+        logging.debug("GitHub 웹훅 서버가 이미 실행 중입니다.")
+        return
+
+    github_app = web.Application()
+    github_app.router.add_post('/github/webhook', handle_github_webhook)
+
+    webhook_runner = web.AppRunner(github_app)
+    await webhook_runner.setup()
+
+    site = web.TCPSite(webhook_runner, host=WEBHOOK_HOST, port=WEBHOOK_PORT)
+    await site.start()
+
+    logging.info(
+        "GitHub 웹훅 서버가 시작되었습니다: http://%s:%s/github/webhook",
+        WEBHOOK_HOST,
+        WEBHOOK_PORT,
+    )
+
+
+async def stop_webhook_server() -> None:
+    """GitHub 웹훅 서버를 종료합니다."""
+
+    global webhook_runner
+
+    if webhook_runner is None:
+        return
+
+    await webhook_runner.cleanup()
+    webhook_runner = None
+
+
+async def main() -> None:
     if not BOT_TOKEN or not XAI_API_KEY:
         print("Please set TELEGRAM_BOT_TOKEN and XAI_API_KEY in .env file")
         return
-    application = Application.builder().token(BOT_TOKEN).build()
-    application.add_handler(CommandHandler("start", start))
-    application.add_handler(CommandHandler("reset", reset_memory))
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
-    application.run_polling(allowed_updates=Update.ALL_TYPES)
+
+    global telegram_application
+    telegram_application = Application.builder().token(BOT_TOKEN).build()
+    telegram_application.add_handler(CommandHandler("start", start))
+    telegram_application.add_handler(CommandHandler("reset", reset_memory))
+    telegram_application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message)
+    )
+
+    await start_webhook_server()
+
+    try:
+        await telegram_application.run_polling(
+            allowed_updates=Update.ALL_TYPES,
+            close_loop=False,
+        )
+    finally:
+        await stop_webhook_server()
+
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv==1.1.1
 python-telegram-bot==22.5
 langchain==0.3.27
 langchain-xai==0.2.5
+aiohttp==3.9.5


### PR DESCRIPTION
## Summary
- avoid closing the asyncio loop out from under the Telegram application by keeping run_polling from closing it
- guard webhook server startup and ensure it cleans up its runner handle when stopping

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe7c7ae448329a7bc848cecc11beb